### PR TITLE
Dockerfile: add /usr/bin/ec2metadata stub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ WORKDIR /
 COPY --from=0 /cps .
 ADD dockerfiles/cps.json /
 ADD dockerfiles/services/ /services
+RUN touch /usr/bin/ec2metadata
 
 EXPOSE 9100/tcp
 


### PR DESCRIPTION
Adds a stub file for /usr/bin/ec2metadata. We need to trick cps into thinking it is running on an ec2 instance so we can get back instance metadata.