### PR TITLE
Dockerfile: install ca-certificates in final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ WORKDIR /
 COPY --from=0 /cps .
 ADD dockerfiles/cps.json /
 ADD dockerfiles/services/ /services
-RUN touch /usr/bin/ec2metadata
+RUN apk add --update-cache ca-certificates && \
+  touch /usr/bin/ec2metadata
 
 EXPOSE 9100/tcp
 


### PR DESCRIPTION
Installs ca-certificates in the final image. Fixes `x509: failed to load system roots and no roots provided`.