### PR TITLE
Use first mac address to find vpc

### DIFF
--- a/pkg/ec2meta/ec2meta.go
+++ b/pkg/ec2meta/ec2meta.go
@@ -225,7 +225,9 @@ func getVpcID(svc *ec2metadata.EC2Metadata) string {
 		return ""
 	}
 
-	v, err := svc.GetMetadata("/network/interfaces/macs/" + m + "/vpc-id")
+	firstMac := strings.Split(m, "\n")[0]
+
+	v, err := svc.GetMetadata("/network/interfaces/macs/" + firstMac + "/vpc-id")
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
Fixes a bug we are seeing when there are more than one mac addresses associated with an ec2 instance. Tested for backwards compatibility with nodes having only one mac address.