### PR TITLE
Add source to container for easy debugging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ COPY --from=0 /cps .
 ADD dockerfiles/cps.json /
 ADD dockerfiles/services/ /services
 RUN apk add --update-cache ca-certificates && \
-  touch /usr/bin/ec2metadata
+  touch /usr/bin/ec2metadata && mkdir -p /go/src/cps
+COPY . /go/src/cps
 
 EXPOSE 9100/tcp
 


### PR DESCRIPTION
To enable easier debugging we've decided to include the source in the final image.