### PR TITLE
Dockerfile: fix gopath

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM golang:1.10.3-alpine3.7
 
-WORKDIR /go/src/cps
+WORKDIR /go/src/github.com/rapid7/cps
 
-COPY . /go/src/cps
+COPY . /go/src/github.com/rapid7/cps
 
 RUN apk add --update-cache git && \
   mkdir -p /etc/cps && \
   go get -u github.com/golang/dep/cmd/dep && \
+  export GOPATH=/go && \
   dep ensure -v && go build -o /cps -v && \
   rm -rf /go/src/cps/*
 


### PR DESCRIPTION
Fixes $GOPATH issues in the dockerfile. Previously dep was treating rapid7/cps as an external dependency.