### PR TITLE
Fixing the remaining lint issues

### DIFF
--- a/api/v1/conqueso/conqueso.go
+++ b/api/v1/conqueso/conqueso.go
@@ -17,8 +17,8 @@ func init() {
 	log.SetOutput(os.Stdout)
 }
 
-// Handler for /v1/conqueso/{service}. Returns a service's properties
-// in the java property style.
+// GetConquesoProperties is a Handler for /v1/conqueso/{service}.
+// It returns a service's properties in the java property style.
 func GetConquesoProperties(w http.ResponseWriter, r *http.Request, account string, region string) {
 	vars := mux.Vars(r)
 	service := vars["service"]
@@ -68,6 +68,8 @@ func GetConquesoProperties(w http.ResponseWriter, r *http.Request, account strin
 	w.Write(output.Bytes())
 }
 
-// Empty handler to deal with a bug in the java conqueso client.
+// PostConqueso is an empty handler constructed to deal with a bug in the java
+// conqueso client. It just needs to accept a POST, it does not need to return
+// anything.
 func PostConqueso(w http.ResponseWriter, r *http.Request) {
 }

--- a/api/v1/health/health.go
+++ b/api/v1/health/health.go
@@ -10,20 +10,20 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Struct wrapper for all health data.
+// Health is a wrapper for all health data.
 type Health struct {
 	Status  int           `json:"status"`
 	Plugins HealthPlugins `json:"plugins"`
 }
 
-// Subset of the Health struct, it contains
-// health information for various components.
+// HealthPlugins is a child of the Health struct. It currently contains health
+// status for consul and S3.
 type HealthPlugins struct {
 	Consul bool `json:"consul"`
 	S3     bool `json:"s3"`
 }
 
-// Handler for the health endpoint. Checks health for
+// GetHealth is a mux handler for the health endpoint. It checks health for
 // various components and returns the results as json.
 func GetHealth(w http.ResponseWriter, r *http.Request) {
 	var status int

--- a/api/v1/health/healthz.go
+++ b/api/v1/health/healthz.go
@@ -10,14 +10,14 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Holds the json response for the /v1/healthz endpoint.
+// Response Holds the json response for the /v1/healthz endpoint.
 type Response struct {
 	Status string `json:"status"`
 	Consul bool   `json:"consul"`
 	S3     bool   `json:"s3"`
 }
 
-// Handler for the /v1/healthz endpoint. It returns detailed
+// GetHealthz is a mux handler for the /v1/healthz endpoint. It returns detailed
 // health information about all dependent services.
 func GetHealthz(w http.ResponseWriter, r *http.Request) {
 	status := "down"

--- a/api/v1/properties/properties.go
+++ b/api/v1/properties/properties.go
@@ -19,13 +19,12 @@ func init() {
 	log.SetOutput(os.Stdout)
 }
 
-// This stuct holds the overall health status of cps
-// and its dependent services
+// Error holds the data to be made into a json error message.
 type Error struct {
 	Status string `json:"status"`
 }
 
-// Handler for the /v1/properties endpoint, returns all
+// GetProperties is a mux handler for the /v1/properties endpoint. It returns all
 // properties for a given service.
 func GetProperties(w http.ResponseWriter, r *http.Request, account string, region string) {
 	vars := mux.Vars(r)
@@ -74,7 +73,7 @@ func GetProperties(w http.ResponseWriter, r *http.Request, account string, regio
 	}
 }
 
-// Handler for getting a single property.
+// GetProperty is a mux handler for getting a single property.
 func GetProperty(w http.ResponseWriter, r *http.Request, account, region string) {
 	vars := mux.Vars(r)
 	service := vars["service"]

--- a/api/v2/health/health.go
+++ b/api/v2/health/health.go
@@ -9,13 +9,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Holds the json response for /v2/healthz.
+// Response holds the json response for /v2/healthz.
 type Response struct {
 	Status string `json:"status"`
 	S3     bool   `json:"s3"`
 }
 
-// Returns basic health status as json.
+// GetHealthz returns the basic health status as json.
 func GetHealthz(w http.ResponseWriter, r *http.Request) {
 	status := "down"
 	if s3.Up {

--- a/api/v2/properties/properties.go
+++ b/api/v2/properties/properties.go
@@ -20,7 +20,7 @@ func init() {
 	log.SetOutput(os.Stdout)
 }
 
-// Error is unused currently but it intented to supply a detailed
+// Error is unused currently but it intended to supply a detailed
 // error message when a GET fails (TODO).
 type Error struct {
 	Status string `json:"status"`

--- a/api/v2/properties/properties.go
+++ b/api/v2/properties/properties.go
@@ -20,15 +20,15 @@ func init() {
 	log.SetOutput(os.Stdout)
 }
 
-// Unused currently but it intented to supply a detailed
+// Error is unused currently but it intented to supply a detailed
 // error message when a GET fails (TODO).
 type Error struct {
 	Status string `json:"status"`
 }
 
-// Handler for the /v2/properties/{service}/* endpoint. It
-// can return all properties for a service or a subset of
-// properties if additional paths are given after {service}.
+// GetProperties is a handler for the /v2/properties/{service}/* endpoint. It
+// can return all properties for a service or a subset of properties if
+// additional paths are given after {service}.
 func GetProperties(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	scope := strings.Split(vars["scope"], "/")

--- a/main.go
+++ b/main.go
@@ -85,7 +85,6 @@ func main() {
 		if fileEnabled {
 			log.Print("File mode is enabled, disabling s3 and consul watchers")
 			s3Enabled = false
-			consulEnabled = false
 			go v2file.Poll(directory, account, region)
 		}
 

--- a/pkg/ec2meta/ec2meta.go
+++ b/pkg/ec2meta/ec2meta.go
@@ -12,7 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Contains all aws instance metadata.
+// Instance contains all aws instance metadata.
 type Instance struct {
 	AmiID            string `json:"ami-id"`
 	AvailabilityZone string `json:"availability-zone"`
@@ -58,7 +58,7 @@ func init() {
 	log.SetOutput(os.Stdout)
 }
 
-// Populates Instance with real or mock data depending
+// Populate populates Instance with real or mock data depending
 // on the environment.
 func Populate(sess *session.Session) Instance {
 	svc := ec2metadata.New(sess)

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -35,14 +35,13 @@ type Source struct {
 	} `yaml:"parameters"`
 }
 
-// The top level struct which the index is mapped to.
+// Index is the top level struct which the index is mapped to.
 type Index struct {
 	Version float64  `yaml:"version"`
 	Sources []Source `yaml:"sources"`
 }
 
-// This function grabs the index from s3 and returns
-// all paths.
+// ParseIndex grabs the index from s3 and returns all file paths.
 func ParseIndex(b, region string) ([]string, error) {
 	jsonBytes, err := getIndexFromS3(b, region)
 	if err != nil {

--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -12,24 +12,24 @@ import (
 *
 **/
 var (
-	// Global map that any package can use to get properties.
+	// Cache is a global map that any package can use to get properties.
 	Cache = sync.Map{}
 )
 
-// Writes a property to the Cache.
+// WriteProperty writes a property to the Cache.
 func WriteProperty(k string, v interface{}) error {
 	Cache.Store(k, v)
 	return nil
 }
 
-// Deletes a property from the Cache.
+// DeleteProperty deletes a property from the Cache.
 func DeleteProperty(k interface{}) error {
 	Cache.Delete(k)
 	log.Printf("Deleted key: %v", k)
 	return nil
 }
 
-// Gets a property from the Cache.
+// GetProperty gets a property from the Cache.
 func GetProperty(k interface{}) interface{} {
 	v, _ := Cache.Load(k)
 	return v

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -19,8 +19,8 @@ func init() {
 	log.SetOutput(os.Stdout)
 }
 
-// Decrypts a KMS secret from its ciphertext.
-// Broken. Do not use. Look away.
+// Decrypt decrypts a KMS secret from its ciphertext. Broken. Do not use.
+// Look away.
 func Decrypt(s []byte) (string, error) {
 	region := "us-east-1"
 

--- a/pkg/secret/ssm.go
+++ b/pkg/secret/ssm.go
@@ -17,7 +17,7 @@ func init() {
 	log.SetOutput(os.Stdout)
 }
 
-// This function parses all properties looking for an
+// GetSSMSecret parses all properties looking for an
 // $ssm key. When found, it gets the ssm parameter store
 // secret and writes the key and secret to the kv store.
 func GetSSMSecret(k string, v []byte) (string, error) {

--- a/watchers/v1/consul/consul.go
+++ b/watchers/v1/consul/consul.go
@@ -14,15 +14,16 @@ import (
 )
 
 var (
-	// If true there are no issues with s3.
+	// Up is a measure of cps's readiness. If true there are no issues with s3.
 	Up bool
 
-	// If false the watcher could not list objects.
-	// There are still probably objects in the kv
-	// store so the service is still considered "Up".
+	// Health is a measure of cps's overall health. If false the watcher
+	// it is likely that the watcher could not list objects. In this case, there
+	// are still probably objects in the kv store so the service is still
+	// considered "Up".
 	Health bool
 
-	// Exports the config struct. Need to make export
+	// Config contains minimal configuration information. Need to export
 	// the config struct itself (TODO).
 	Config       config
 	healthyNodes map[string][]string
@@ -40,7 +41,7 @@ func init() {
 	log.SetOutput(os.Stdout)
 }
 
-// Polls every 60 seconds, kicking off a consul sync.
+// Poll polls every 60 seconds, kicking off a consul sync.
 func Poll(host string) {
 	Config = config{
 		host: host,
@@ -63,9 +64,8 @@ func Poll(host string) {
 	}()
 }
 
-// This function connects to consul, gets a list of
-// services and their health. Finally, it puts all
-// healthy services into the kv store.
+// Sync connects to consul and gets a list of services and their health.
+// Finally, it puts all healthy services into the kv store.
 func Sync(t time.Time) {
 	log.Print("consul sync begun")
 

--- a/watchers/v1/file/file.go
+++ b/watchers/v1/file/file.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 var (
-	// A global for the config struct. The config
+	// Config is a global for the config struct. The config
 	// struct below should just be exported (TODO).
 	Config config
 )
@@ -33,7 +33,7 @@ type config struct {
 	region    string
 }
 
-// Polls every 60 seconds, causing the application
+// Poll polls every 60 seconds, causing the application
 // to parse the files in the supplied directory.
 func Poll(directory, account, region string) {
 	Config = config{
@@ -59,9 +59,8 @@ func Poll(directory, account, region string) {
 	}()
 }
 
-// This function performs the actual work of
-// traversing the supplied directory and adding
-// properties to the kv store.
+// Sync performs the actual work of traversing the supplied
+// directory and adding properties to the kv store.
 func Sync(t time.Time) {
 	absPath, _ := filepath.Abs(Config.directory)
 

--- a/watchers/v1/s3/s3.go
+++ b/watchers/v1/s3/s3.go
@@ -25,13 +25,14 @@ import (
 )
 
 var (
-	// If true the s3 service is up.
+	// Up contains the systems availability. If true the s3 service is up.
 	Up bool
 
-	// If false the s3 service most likely can't read
-	// or download from s3. Most likely temporary.read
-	// or download from s3. Most likely temporary.
+	// Health contains the systems readiness. If false the s3 service
+	// most likely can't read or download from s3. Most likely temporary.
 	Health bool
+
+	// Config contains parameters related to S3.
 	Config config
 )
 
@@ -46,10 +47,9 @@ func init() {
 
 	log.SetFormatter(&log.JSONFormatter{})
 	log.SetOutput(os.Stdout)
-	// log.SetLevel(log.DebugLevel)
 }
 
-// Polls every 60 seconds, kicking of an s3 sync.
+// Poll polls every 60 seconds, kicking of an s3 sync.
 func Poll(bucket, bucketRegion string) {
 	Config = config{
 		bucket:       bucket,
@@ -73,7 +73,7 @@ func Poll(bucket, bucketRegion string) {
 	}()
 }
 
-// Sets up an s3 session, parses all files and puts
+// Sync sets up an s3 session, parses all files and puts
 // them into the kv store.
 func Sync() {
 	log.Print("s3 sync begun")

--- a/watchers/v2/file/file.go
+++ b/watchers/v2/file/file.go
@@ -18,7 +18,7 @@ func init() {
 }
 
 var (
-	// Global reference to the config struct. The struct just
+	// Config is a global reference to the config struct. The struct just
 	// needs to be exported (TODO).
 	Config config
 )
@@ -29,7 +29,7 @@ type config struct {
 	region    string
 }
 
-// Constructs a poller for files in the directory supplied.
+// Poll constructs a poller for files in the directory supplied.
 func Poll(directory, account, region string) {
 	Config = config{
 		directory: directory,
@@ -54,7 +54,7 @@ func Poll(directory, account, region string) {
 	}()
 }
 
-// Traverses all files in Config.directory and writes them
+// Sync traverses all files in Config.directory and writes them
 // to the kv store.
 func Sync(t time.Time) {
 	absPath, _ := filepath.Abs(Config.directory)

--- a/watchers/v2/s3/s3.go
+++ b/watchers/v2/s3/s3.go
@@ -160,7 +160,7 @@ func parseAllFiles(resp []*s3.ListObjectsOutput, bucket string, svc s3iface.S3AP
 func getPropertyFiles(files []string, b string, svc s3iface.S3API) error {
 	services := make(map[string]interface{})
 
-	for i, f := range files {
+	for _, f := range files {
 		body, _ := getFile(f, b, svc)
 		pathSplit := strings.Split(f, "/")
 		service := pathSplit[len(pathSplit)-1]
@@ -173,8 +173,6 @@ func getPropertyFiles(files []string, b string, svc s3iface.S3API) error {
 		}
 
 		services[serviceName] = serviceProperties
-
-		i++
 	}
 
 	s, err := injectSecrets(services)

--- a/watchers/v2/s3/s3.go
+++ b/watchers/v2/s3/s3.go
@@ -25,15 +25,15 @@ import (
 )
 
 var (
-	// If true there are no issues with s3.
+	// Up contains the systems availability. If true there are no issues with s3.
 	Up bool
 
-	// If false the watcher could not list objects.
-	// There are still probably objects in the kv
+	// Health contains the system's readiness. If false the watcher
+	// could not list objects. There are still probably objects in the kv
 	// store so the service is still considered "Up".
 	Health bool
 
-	// Exports the config struct. Need to make export
+	// Config exports the config struct. Need to make export
 	// the config struct itself (TODO).
 	Config config
 	isJSON = regexp.MustCompile(".json$")
@@ -50,7 +50,7 @@ func init() {
 	log.SetOutput(os.Stdout)
 }
 
-// Polls every 60 seconds, kicking off an S3 sync.
+// Poll polls every 60 seconds, kicking off an S3 sync.
 func Poll(bucket, bucketRegion string) {
 	Config = config{
 		bucket:       bucket,
@@ -74,7 +74,7 @@ func Poll(bucket, bucketRegion string) {
 	}()
 }
 
-// Main function for the s3 watcher. It sets up the
+// Sync is the main function for the s3 watcher. It sets up the
 // AWS session, lists all items in the bucket, finally
 // parsing all files and putting them in the kv store.
 func Sync() {


### PR DESCRIPTION
- `golint` requires comments on exported types and functions to start with the function or type name, this fixes that.