### PR TITLE
Consider whether consul is enabled when determining health

### DIFF
--- a/api/v1/health/health.go
+++ b/api/v1/health/health.go
@@ -25,9 +25,9 @@ type HealthPlugins struct {
 
 // GetHealth is a mux handler for the health endpoint. It checks health for
 // various components and returns the results as json.
-func GetHealth(w http.ResponseWriter, r *http.Request, log *zap.Logger) {
+func GetHealth(w http.ResponseWriter, r *http.Request, log *zap.Logger, consulEnabled bool) {
 	var status int
-	if s3.Health == true && consul.Health == true {
+	if (s3.Health == true && !consulEnabled) || (s3.Health == true && consul.Health == true && consulEnabled) {
 		status = 200
 	} else {
 		status = 503

--- a/api/v1/health/health_test.go
+++ b/api/v1/health/health_test.go
@@ -20,9 +20,10 @@ func TestGetHealth(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	consulEnabled := false
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		GetHealth(w, r, log)
+		GetHealth(w, r, log, consulEnabled)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -31,12 +32,13 @@ func TestGetHealth(t *testing.T) {
 		t.Errorf("Status code is wrong when unhealthy: expected %v got %v", status, http.StatusServiceUnavailable)
 	}
 
+	consulEnabled = true
 	consul.Health = true
 	s3.Health = true
 
 	rr = httptest.NewRecorder()
 	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		GetHealth(w, r, log)
+		GetHealth(w, r, log, consulEnabled)
 	})
 
 	handler.ServeHTTP(rr, req)

--- a/api/v1/health/healthz.go
+++ b/api/v1/health/healthz.go
@@ -18,9 +18,9 @@ type Response struct {
 
 // GetHealthz is a mux handler for the /v1/healthz endpoint. It returns detailed
 // health information about all dependent services.
-func GetHealthz(w http.ResponseWriter, r *http.Request, log *zap.Logger) {
+func GetHealthz(w http.ResponseWriter, r *http.Request, log *zap.Logger, consulEnabled bool) {
 	status := "down"
-	if s3.Up == true && consul.Up == true {
+	if (s3.Up == true && !consulEnabled) || (s3.Up == true && consul.Up == true && consulEnabled) {
 		status = "up"
 	}
 

--- a/api/v1/health/healthz_test.go
+++ b/api/v1/health/healthz_test.go
@@ -23,9 +23,10 @@ func TestGetHealthz(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	consulEnabled := false
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		GetHealthz(w, r, log)
+		GetHealthz(w, r, log, consulEnabled)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -37,12 +38,13 @@ func TestGetHealthz(t *testing.T) {
 	expectedJSON := `{"status":"down","consul":false,"s3":false}`
 	assert.Equal(t, expectedJSON, rr.Body.String())
 
+	consulEnabled = true
 	consul.Up = true
 	s3.Up = true
 
 	rr = httptest.NewRecorder()
 	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		GetHealthz(w, r, log)
+		GetHealthz(w, r, log, consulEnabled)
 	})
 
 	handler.ServeHTTP(rr, req)

--- a/main.go
+++ b/main.go
@@ -131,12 +131,12 @@ func main() {
 
 		// Health returns detailed information about CPS health.
 		router.HandleFunc("/v1/health", func(w http.ResponseWriter, r *http.Request) {
-			health.GetHealth(w, r, log)
+			health.GetHealth(w, r, log, consulEnabled)
 		}).Methods("GET")
 
 		// Healthz returns only basic health.
 		router.HandleFunc("/v1/healthz", func(w http.ResponseWriter, r *http.Request) {
-			health.GetHealthz(w, r, log)
+			health.GetHealthz(w, r, log, consulEnabled)
 		}).Methods("GET")
 	}
 


### PR DESCRIPTION
Previously, in the v1 api, consul had to be up for cps to be considered healthy. If consul is disabled we now ignore it.