### PR TITLE
Ensure images generated from the Dockerfile statically link the commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,13 @@ FROM golang:1.10.3-alpine3.7
 
 WORKDIR /go/src/github.com/rapid7/cps
 
-COPY . /go/src/github.com/rapid7/cps
-
-RUN apk add --update-cache git && \
+RUN apk add --update-cache git make && \
+  git clone https://github.com/rapid7/cps.git . && \
   mkdir -p /etc/cps && \
   go get -u github.com/golang/dep/cmd/dep && \
   export GOPATH=/go && \
-  dep ensure -v && make build && mv cps /
-  
+  dep ensure -v && make build && mv cps /cps
+
 FROM alpine:latest
 
 WORKDIR /


### PR DESCRIPTION
Previous images did not have the build commit in the logs. This PR ensures the commit is in the logs. Also fixes a bug or two.