### PR TITLE
PD-30773: Add test PR job using github actions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
 
-  build:
+  test:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: |
+        docker build -t cps-test -f testcontainer/Dockerfile .
+        docker run cps-test

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: Run Go Tests
 
 on:
   pull_request:
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Build the Docker image
+    - name: Run Go Tests
       run: |
         docker build -t cps-test -f testcontainer/Dockerfile .
         docker run cps-test

--- a/api/v1/health/healthz_test.go
+++ b/api/v1/health/healthz_test.go
@@ -22,7 +22,7 @@ func TestGetHealthz(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-    t.Fatal("Forcing error")
+
 	consulEnabled := false
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/v1/health/healthz_test.go
+++ b/api/v1/health/healthz_test.go
@@ -22,7 +22,7 @@ func TestGetHealthz(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
+    t.Fatal("Forcing error")
 	consulEnabled := false
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/testcontainer/Dockerfile
+++ b/testcontainer/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:latest
+
+WORKDIR /src
+COPY . /src
+RUN apk add --update-cache git make && \
+    apk add go=1.16.7-r0 && \
+    wget https://releases.hashicorp.com/consul/1.2.2/consul_1.2.2_linux_amd64.zip && \
+    unzip consul_1.2.2_linux_amd64.zip && \
+    mv consul /usr/bin/
+
+CMD ["make", "test"]


### PR DESCRIPTION
Adding a github actions job to run go tests on PRs against the master branch. These tests will be required to pass before a PR can be merged into the master branch. The job uses a dockerfile which sets up the test environment and runs make test. Using make for triggering the tests so that we can keep our test definitions in a single location. 