### PR TITLE
PD-42346 - Allow picking up environment vars for config data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,9 @@ FROM alpine:latest
 WORKDIR /
 
 COPY --from=0 /cps .
-ADD dockerfiles/cps.json /
-ADD dockerfiles/services/ /services
+# Local testing
+# ADD dockerfiles/cps.json /
+# ADD dockerfiles/services/ /services
 RUN apk add --update-cache ca-certificates && \
   touch /usr/bin/ec2metadata && mkdir -p /go/src/cps
 COPY . /go/src/cps

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The names of the files in the `./local-files` should be the name of the service.
 
 There is a Dockerfile at the root of the project that is meant to be used in local file mode. You can modify `dockerfiles/cps.json` and add/remove services from the `dockerfiles/services` directory to change what properties are returned. Here are the steps to get started quickly:
 
-1. `docker build -t cps .`
-2. `docker run -p 9100:9100 -it cps`
-3. `curl localhost:9100/v1/properties/your-service`
+1. Uncomment dockerfiles ADD in Dockerfile
+2. `docker build -t cps .`
+3. `docker run -p 9100:9100 -it cps`
+4. `curl localhost:9100/v1/properties/your-service`

--- a/main.go
+++ b/main.go
@@ -37,10 +37,10 @@ func main() {
 	viper.AddConfigPath(".")
 	if configFile != "" {
 		viper.SetConfigFile(configFile)
-		err := viper.ReadInConfig()
-		if err != nil {
-			panic(fmt.Sprintf("Fatal error reading in config file: %s", err))
-		}
+	}
+	err := viper.ReadInConfig()
+	if err != nil {
+		fmt.Sprintf("Cannot read config file: %s. Will use ENV variables if present", err)
 	}
 	replacer := strings.NewReplacer(".", "_")
 	viper.SetEnvKeyReplacer(replacer)

--- a/main.go
+++ b/main.go
@@ -44,8 +44,10 @@ func main() {
 	}
 	replacer := strings.NewReplacer(".", "_")
 	viper.SetEnvKeyReplacer(replacer)
-	viper.SetEnvPrefix("cps")
+	viper.SetEnvPrefix("cps_conf")
 	viper.AutomaticEnv()
+	fmt.Printf("account=%v\n", viper.Get("account"))
+	fmt.Printf("region=%v\n", viper.Get("region"))
 	fmt.Printf("s3.bucket=%v\n", viper.Get("s3.bucket"))
 	fmt.Printf("consul.enabled=%v\n", viper.GetBool("consul.enabled"))
 	fmt.Printf("api.version=%v\n", viper.GetInt("api.version"))
@@ -88,7 +90,7 @@ func main() {
 		log.Fatal("Config `s3.bucket` is required!")
 	}
 
-	viper.SetDefault("s3.region", "us-east-1")
+	viper.SetDefault("s3.region", region)
 	bucketRegion := viper.GetString("s3.region")
 
 	viper.SetDefault("consul.host", "localhost:8500")


### PR DESCRIPTION
Updates to allow support for using of environment variables which will be used in stemcell-podman
Commenting out "dockerfiles" in the Dockerfile as these are only used for local testing and don't need to be on the production image

Tested on
komand-int-1 eks
komand int stemcell-podman
Confirmed can get properties back