### PR TITLE
PD-43447 - GetSSMSecretWithLabels - Add if else to handle without ser…

### DIFF
--- a/secret/ssm.go
+++ b/secret/ssm.go
@@ -50,7 +50,7 @@ func GetSSMSecretWithLabels(ctx context.Context, svc SSMAPI, name string, cred S
 	}
 	path := "/"
 	if cred.SSM.Service != "" {
-		path += cred.SSM.Service
+		path += cred.SSM.Service+"/"
 	}
 
 	params := &ssm.GetParametersByPathInput{
@@ -83,7 +83,12 @@ func GetSSMSecretWithLabels(ctx context.Context, svc SSMAPI, name string, cred S
 	var found string
 	for _, param := range p.Parameters {
 		parameterName := aws.StringValue(param.Name)
-		if strings.Replace(parameterName, path+"/", "", 1) == name {
+		if cred.SSM.Service != "" {
+			if strings.Replace(parameterName, path, "", 1) == name {
+				found = aws.StringValue(param.Value)
+				break
+			}
+		} else {
 			found = aws.StringValue(param.Value)
 			break
 		}


### PR DESCRIPTION
…vice

If a service is not defined for the secret in the properties file - example here - https://github.com/rapid7/giraffe-properties/blob/master/services/attackerkb.yml#L240 -  in v2 secrets handler then the param is not found with error below - however this does exist but the _if strings.Replace_ statement will never be true

Error:
```
{"level":"ERROR","time":"2024-02-08T11:24:53.533Z","caller":"s3/s3.go:309","message":"error handling SSM secret","commit":"4eea6cf","error":"no matching parameter found","key":"auth.twitter_secret"}
```

This update is just to add a rubbish if/else onto this to force it to check for the param even if there is no service

Testing

Tested this with a secret that has and has not a service defined in giraffe - Can confirm both work 

Also tested in log entries, however from what I can see no other teams use v2 of the secrets handler so this does not become a problem

Test psimms created with defining a service, auth.twitter was defined without a service
```
psimms@BFS-MBP-11612 ~ % curl localhost:9100/v2/properties/psimms/test.secret
TOP_SECRET
psimms@BFS-MBP-11612 ~ % curl localhost:9100/v2/properties/attackerkb/auth.twitter_secret
<secret-string-here>
```