### PR TITLE
PD-43447 - GetSSMSecretWithLabels - Handle nextToken

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,6 +128,7 @@ func main() {
 		if s3Enabled {
 			viper.SetDefault("secret.version", int(v2s3.V1))
 			secretVersion := viper.GetInt("secret.version")
+			fmt.Printf("secret.version=%v\n", secretVersion)
 			sv := v2s3.SecretHandlerVersion(secretVersion)
 			go v2s3.Poll(bucket, bucketRegion, sv, log)
 		}

--- a/secret/ssm.go
+++ b/secret/ssm.go
@@ -50,7 +50,7 @@ func GetSSMSecretWithLabels(ctx context.Context, svc SSMAPI, name string, cred S
 	}
 	path := "/"
 	if cred.SSM.Service != "" {
-		path += cred.SSM.Service+"/"
+		path += cred.SSM.Service + "/"
 	}
 
 	var nextToken *string
@@ -59,7 +59,7 @@ func GetSSMSecretWithLabels(ctx context.Context, svc SSMAPI, name string, cred S
 		params := &ssm.GetParametersByPathInput{
 			Path:           aws.String(path),
 			WithDecryption: aws.Bool(true),
-			NextToken: nextToken,
+			NextToken:      nextToken,
 		}
 
 		if cred.SSM.Label != "" {
@@ -88,7 +88,7 @@ func GetSSMSecretWithLabels(ctx context.Context, svc SSMAPI, name string, cred S
 			parameterName := aws.StringValue(param.Name)
 			if strings.Replace(parameterName, path, "", 1) == name {
 				found = aws.StringValue(param.Value)
-				break
+				goto Found
 			}
 		}
 		nextToken = p.NextToken
@@ -106,6 +106,7 @@ func GetSSMSecretWithLabels(ctx context.Context, svc SSMAPI, name string, cred S
 			break
 		}
 	}
+Found:
 	return found, nil
 }
 

--- a/secret/ssm.go
+++ b/secret/ssm.go
@@ -53,59 +53,59 @@ func GetSSMSecretWithLabels(ctx context.Context, svc SSMAPI, name string, cred S
 		path += cred.SSM.Service+"/"
 	}
 
-	params := &ssm.GetParametersByPathInput{
-		Path:           aws.String(path),
-		WithDecryption: aws.Bool(true),
-	}
-
-	if cred.SSM.Label != "" {
-		params.ParameterFilters = []*ssm.ParameterStringFilter{
-			{
-				Key:    aws.String("Label"),
-				Option: aws.String("Equals"),
-				Values: aws.StringSlice([]string{cred.SSM.Label}),
-			},
-		}
-	}
-
-	p, err := svc.GetParametersByPathWithContext(ctx, params)
-	if err != nil {
-		log.Error("Error getting SSM parameters",
-			zap.Error(err),
-			zap.String("path", path),
-			zap.String("label", cred.SSM.Label),
-			zap.String("key", name),
-		)
-
-		return "", err
-	}
-
+	var nextToken *string
 	var found string
-	for _, param := range p.Parameters {
-		parameterName := aws.StringValue(param.Name)
-		if cred.SSM.Service != "" {
+	for {
+		params := &ssm.GetParametersByPathInput{
+			Path:           aws.String(path),
+			WithDecryption: aws.Bool(true),
+			NextToken: nextToken,
+		}
+
+		if cred.SSM.Label != "" {
+			params.ParameterFilters = []*ssm.ParameterStringFilter{
+				{
+					Key:    aws.String("Label"),
+					Option: aws.String("Equals"),
+					Values: aws.StringSlice([]string{cred.SSM.Label}),
+				},
+			}
+		}
+
+		p, err := svc.GetParametersByPathWithContext(ctx, params)
+		if err != nil {
+			log.Error("Error getting SSM parameters",
+				zap.Error(err),
+				zap.String("path", path),
+				zap.String("label", cred.SSM.Label),
+				zap.String("key", name),
+			)
+
+			return "", err
+		}
+
+		for _, param := range p.Parameters {
+			parameterName := aws.StringValue(param.Name)
 			if strings.Replace(parameterName, path, "", 1) == name {
 				found = aws.StringValue(param.Value)
 				break
 			}
-		} else {
-			found = aws.StringValue(param.Value)
+		}
+		nextToken = p.NextToken
+		if nextToken == nil {
+			if found == "" {
+				err := errors.New("no matching parameter found")
+				log.Error("Error getting SSM parameter",
+					zap.Error(err),
+					zap.String("path", path),
+					zap.String("label", cred.SSM.Label),
+					zap.String("key", name),
+				)
+				return "", err
+			}
 			break
 		}
 	}
-
-	if found == "" {
-		err := errors.New("no matching parameter found")
-		log.Error("Error getting SSM parameter",
-			zap.Error(err),
-			zap.String("path", path),
-			zap.String("label", cred.SSM.Label),
-			zap.String("key", name),
-		)
-
-		return "", err
-	}
-
 	return found, nil
 }
 


### PR DESCRIPTION
- Adding handling of nextToken, if there are params more than 10 results this would not find x parameter
- Also removed the if/else statement as that was broken - my fault - we can just use the same logic for a param that has a service vs does not

Pagination would be better however that is only supported in v2 of the go aws sdk - I was going to test with something like this but couldn't due to needing v2
```
	paginator := &ssm.NewGetParametersByPathPaginator(svc ,params)
		for paginator.Next(ctx) {
			page := paginator.CurrentPage()
			for _, param := range page.Parameters {
				parameterName := aws.StringValue(param.Name)
				if strings.Replace(parameterName, path, "", 1) == name {
					found := aws.StringValue(param.Value)
					break
				}
			}
		}
```

Looked a bit at migrating to v2 but think thats a bigger task than what I want to tackle currently